### PR TITLE
Fix setup method declaration

### DIFF
--- a/src/MonacoEditor.php
+++ b/src/MonacoEditor.php
@@ -37,7 +37,7 @@ class MonacoEditor extends Field
 
     protected string $view = 'filament-monaco-editor::filament-monaco-editor';
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->showPlaceholder = config('filament-monaco-editor.general.show-placeholder');
         $this->placeholderText = config('filament-monaco-editor.general.placeholder-text');


### PR DESCRIPTION
              Maybe this is related but when I tried this plugin it shows these errors:

`Declaration of AbdelhamidErrahmouni\FilamentMonacoEditor\MonacoEditor::setUp() must be compatible with Filament\Support\Components\Component::setUp(): void`

_Originally posted by @199ocero in https://github.com/abdelhamiderrahmouni/filament-monaco-editor/issues/4#issuecomment-2114048300_
            
See https://github.com/abdelhamiderrahmouni/filament-monaco-editor/commit/a12da680ed137b5234c9acdab83b490247d0ea45#diff-1999aca23e2b0e556cf0f77fa99eaf5bba36d577c2aa8c7b5dfb37ff6b507172R40