### PR TITLE
Downgrade to php 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "filament/forms": "^4.0",
         "spatie/laravel-package-tools": "^1.15.0"
     },


### PR DESCRIPTION
https://filamentphp.com/docs/4.x/introduction/installation
<img width="319" height="251" alt="image" src="https://github.com/user-attachments/assets/85983f6b-87c5-4d58-a11c-c4f17bea9dc6" />

Filament didn't require 8.3 and it works just fine with 8.2 so why bump it ?